### PR TITLE
Weather module source to WeatherAPI.com

### DIFF
--- a/app/libraries/main.php
+++ b/app/libraries/main.php
@@ -5709,7 +5709,8 @@ class MEC_main extends MEC_base
         ))) $locale = 'en';
 
         // Dark Sky Provider
-        $JSON = $this->get_web_page('https://api.darksky.net/forecast/'.$settings['weather_module_api_key'].'/'.$lat.','.$lng.','.strtotime($datetime).'?exclude=minutely,hourly,daily,alerts&units=ca&lang='.$locale);
+        // $JSON = $this->get_web_page('https://api.darksky.net/forecast/'.$settings['weather_module_api_key'].'/'.$lat.','.$lng.','.strtotime($datetime).'?exclude=minutely,hourly,daily,alerts&units=ca&lang='.$locale);
+        $JSON = $this->get_web_page('https://api.weatherapi.com/v1/forecast.json?key='.$settings['weather_module_api_key'].'&q='.$lat.','.$lng);
         $data = json_decode($JSON, true);
 
         return (isset($data['currently']) ? $data['currently'] : false);

--- a/app/modules/weather/details.php
+++ b/app/modules/weather/details.php
@@ -30,53 +30,53 @@ $date = (trim($occurrence) ? $occurrence : $event->date['start']['date']).' '.sp
 $weather = $this->get_weather($lat, $lng, $date);
 $imperial = (isset($settings['weather_module_imperial_units']) and $settings['weather_module_imperial_units']) ? true : false;
 
-// Weather not found!
-if(!is_array($weather) or (is_array($weather) and !count($weather))) return;
 ?>
 <div class="mec-weather-details mec-frontbox" id="mec_weather_details">
-    <h3 class="mec-weather mec-frontbox-title"><?php _e('Weather', 'modern-events-calendar-lite'); ?></h3>
+    <h3 class="mec-weather mec-frontbox-title"><?php _e('Weather', 'mec'); ?></h3>
 
     <!-- mec weather start -->
     <div class="mec-weather-box">
 
         <div class="mec-weather-head">
             <div class="mec-weather-icon-box">
-                <span class="mec-weather-icon <?php echo $weather['icon']; ?>"></span>
+                <?php  $url= str_replace('//', '', $weather['condition']['icon']); $icon = 'style="background-size: 100%; background-image: url(http://'.$url.')"'; ?>
+                <span class="mec-weather-icon" <?php echo $icon ?>></span>
             </div>
             <div class="mec-weather-summary">
 
-                <?php if(isset($weather['summary'])): ?>
-                <div class="mec-weather-summary-report"><?php echo $weather['summary']; ?></div>
+                <?php if(isset($weather['condition']['text'])): ?>
+                <div class="mec-weather-summary-report"><?php echo $weather['condition']['text']; ?></div>
                 <?php endif; ?>
 
-                <?php if(isset($weather['temperature'])): ?>
-                    <div class="mec-weather-summary-temp" data-c="<?php _e( ' °C', 'modern-events-calendar-lite' ); ?>" data-f="<?php _e( ' °F', 'modern-events-calendar-lite' ); ?>">
-                    <?php if(!$imperial): echo round($weather['temperature']); ?>
-                    <var><?php _e(' °C', 'modern-events-calendar-lite'); ?></var>
-                    <?php else: echo $this->weather_unit_convert($weather['temperature'], 'C_TO_F'); ?>
-                    <var><?php _e(' °F', 'modern-events-calendar-lite'); ?></var>
-                    <?php endif; ?>
+                <?php if(isset($weather['temp_c'])): ?>
+                    <div class="mec-weather-summary-temp" data-c="<?php _e( ' °C', 'mec' ); ?>" data-f="<?php _e( ' °F', 'mec' ); ?>">
+                        <?php if(!$imperial): echo round($weather['temp_c']); ?>
+                            <var><?php _e(' °C', 'mec'); ?></var>
+                        <?php else: echo $this->weather_unit_convert($weather['temp_c'], 'C_TO_F'); ?>
+                            <var><?php _e(' °F', 'mec'); ?></var>
+                        <?php endif; ?>
                     </div>
                 <?php endif; ?>
+                
 
             </div>
             
             <?php if(isset($settings['weather_module_change_units_button']) and $settings['weather_module_change_units_button']): ?>
-            <span data-imperial="<?php _e('°Imperial', 'modern-events-calendar-lite'); ?>" data-metric="<?php _e('°Metric', 'modern-events-calendar-lite'); ?>" class="degrees-mode"><?php if(!$imperial) _e('°Imperial', 'modern-events-calendar-lite'); else _e('°Metric', 'modern-events-calendar-lite'); ?></span>
+            <span data-imperial="<?php _e('°Imperial', 'mec'); ?>" data-metric="<?php _e('°Metric', 'mec'); ?>" class="degrees-mode"><?php if(!$imperial) _e('°Imperial', 'mec'); else _e('°Metric', 'mec'); ?></span>
             <?php endif ?>
             
             <div class="mec-weather-extras">
 
-                <?php if(isset($weather['windSpeed'])): ?>
-                <div class="mec-weather-wind" data-kph="<?php _e(' KPH', 'modern-events-calendar-lite'); ?>" data-mph="<?php _e(' MPH', 'modern-events-calendar-lite'); ?>"><span><?php _e('Wind', 'modern-events-calendar-lite'); ?>: </span><?php if(!$imperial) echo round($weather['windSpeed']); else  echo $this->weather_unit_convert($weather['windSpeed'], 'KM_TO_M');?><var><?php if(!$imperial) _e(' KPH', 'modern-events-calendar-lite'); else _e(' MPH', 'modern-events-calendar-lite'); ?></var></div>
+                <?php if(isset($weather['wind_kph'])): ?>
+                <div class="mec-weather-wind" data-kph="<?php _e(' KPH', 'mec'); ?>" data-mph="<?php _e(' MPH', 'mec'); ?>"><span><?php _e('Wind', 'mec'); ?>: </span><?php if(!$imperial) echo round($weather['wind_kph']); else  echo $this->weather_unit_convert($weather['wind_kph'], 'KM_TO_M');?><var><?php if(!$imperial) _e(' KPH', 'mec'); else _e(' MPH', 'mec'); ?></var></div>
                 <?php endif; ?>
 
                 <?php if(isset($weather['humidity'])): ?>
-                    <div class="mec-weather-humidity"><span><?php _e('Humidity', 'modern-events-calendar-lite'); ?>:</span> <?php echo round($weather['humidity']); ?><var><?php _e(' %','modern-events-calendar-lite'); ?></var></div>
+                    <div class="mec-weather-humidity"><span><?php _e('Humidity', 'mec'); ?>:</span> <?php echo round($weather['humidity']); ?><var><?php _e(' %','mec'); ?></var></div>
                 <?php endif; ?>
 
-                <?php if(isset($weather['visibility'])): ?>
-                    <div class="mec-weather-visibility" data-kph="<?php _e(' KM', 'modern-events-calendar-lite'); ?>" data-mph="<?php _e(' Miles', 'modern-events-calendar-lite'); ?>"><span><?php _e('Visibility', 'modern-events-calendar-lite'); ?>: </span><?php if(!$imperial) echo round($weather['visibility']); else  echo $this->weather_unit_convert($weather['visibility'], 'KM_TO_M');?><var><?php if(!$imperial) _e(' KM','modern-events-calendar-lite'); else _e(' Miles','modern-events-calendar-lite'); ?></var></div>
+                <?php if(isset($weather['vis_km'])): ?>
+                    <div class="mec-weather-visibility" data-kph="<?php _e(' KM', 'mec'); ?>" data-mph="<?php _e(' Miles', 'mec'); ?>"><span><?php _e('Visibility', 'mec'); ?>: </span><?php if(!$imperial) echo round($weather['vis_km']); else  echo $this->weather_unit_convert($weather['vis_km'], 'KM_TO_M');?><var><?php if(!$imperial) _e(' KM','mec'); else _e(' Miles','mec'); ?></var></div>
                 <?php endif; ?>
         
             </div>

--- a/app/modules/weather/details.php
+++ b/app/modules/weather/details.php
@@ -32,7 +32,7 @@ $imperial = (isset($settings['weather_module_imperial_units']) and $settings['we
 
 ?>
 <div class="mec-weather-details mec-frontbox" id="mec_weather_details">
-    <h3 class="mec-weather mec-frontbox-title"><?php _e('Weather', 'mec'); ?></h3>
+    <h3 class="mec-weather mec-frontbox-title"><?php _e('Weather', 'modern-events-calendar-lite'); ?></h3>
 
     <!-- mec weather start -->
     <div class="mec-weather-box">
@@ -49,11 +49,11 @@ $imperial = (isset($settings['weather_module_imperial_units']) and $settings['we
                 <?php endif; ?>
 
                 <?php if(isset($weather['temp_c'])): ?>
-                    <div class="mec-weather-summary-temp" data-c="<?php _e( ' °C', 'mec' ); ?>" data-f="<?php _e( ' °F', 'mec' ); ?>">
+                    <div class="mec-weather-summary-temp" data-c="<?php _e( ' °C', 'modern-events-calendar-lite' ); ?>" data-f="<?php _e( ' °F', 'modern-events-calendar-lite' ); ?>">
                         <?php if(!$imperial): echo round($weather['temp_c']); ?>
-                            <var><?php _e(' °C', 'mec'); ?></var>
+                            <var><?php _e(' °C', 'modern-events-calendar-lite'); ?></var>
                         <?php else: echo $this->weather_unit_convert($weather['temp_c'], 'C_TO_F'); ?>
-                            <var><?php _e(' °F', 'mec'); ?></var>
+                            <var><?php _e(' °F', 'modern-events-calendar-lite'); ?></var>
                         <?php endif; ?>
                     </div>
                 <?php endif; ?>
@@ -62,21 +62,21 @@ $imperial = (isset($settings['weather_module_imperial_units']) and $settings['we
             </div>
             
             <?php if(isset($settings['weather_module_change_units_button']) and $settings['weather_module_change_units_button']): ?>
-            <span data-imperial="<?php _e('°Imperial', 'mec'); ?>" data-metric="<?php _e('°Metric', 'mec'); ?>" class="degrees-mode"><?php if(!$imperial) _e('°Imperial', 'mec'); else _e('°Metric', 'mec'); ?></span>
+            <span data-imperial="<?php _e('°Imperial', 'modern-events-calendar-lite'); ?>" data-metric="<?php _e('°Metric', 'modern-events-calendar-lite'); ?>" class="degrees-mode"><?php if(!$imperial) _e('°Imperial', 'modern-events-calendar-lite'); else _e('°Metric', 'modern-events-calendar-lite'); ?></span>
             <?php endif ?>
             
             <div class="mec-weather-extras">
 
                 <?php if(isset($weather['wind_kph'])): ?>
-                <div class="mec-weather-wind" data-kph="<?php _e(' KPH', 'mec'); ?>" data-mph="<?php _e(' MPH', 'mec'); ?>"><span><?php _e('Wind', 'mec'); ?>: </span><?php if(!$imperial) echo round($weather['wind_kph']); else  echo $this->weather_unit_convert($weather['wind_kph'], 'KM_TO_M');?><var><?php if(!$imperial) _e(' KPH', 'mec'); else _e(' MPH', 'mec'); ?></var></div>
+                <div class="mec-weather-wind" data-kph="<?php _e(' KPH', 'modern-events-calendar-lite'); ?>" data-mph="<?php _e(' MPH', 'modern-events-calendar-lite'); ?>"><span><?php _e('Wind', 'modern-events-calendar-lite'); ?>: </span><?php if(!$imperial) echo round($weather['wind_kph']); else  echo $this->weather_unit_convert($weather['wind_kph'], 'KM_TO_M');?><var><?php if(!$imperial) _e(' KPH', 'modern-events-calendar-lite'); else _e(' MPH', 'modern-events-calendar-lite'); ?></var></div>
                 <?php endif; ?>
 
                 <?php if(isset($weather['humidity'])): ?>
-                    <div class="mec-weather-humidity"><span><?php _e('Humidity', 'mec'); ?>:</span> <?php echo round($weather['humidity']); ?><var><?php _e(' %','mec'); ?></var></div>
+                    <div class="mec-weather-humidity"><span><?php _e('Humidity', 'modern-events-calendar-lite'); ?>:</span> <?php echo round($weather['humidity']); ?><var><?php _e(' %','modern-events-calendar-lite'); ?></var></div>
                 <?php endif; ?>
 
                 <?php if(isset($weather['vis_km'])): ?>
-                    <div class="mec-weather-visibility" data-kph="<?php _e(' KM', 'mec'); ?>" data-mph="<?php _e(' Miles', 'mec'); ?>"><span><?php _e('Visibility', 'mec'); ?>: </span><?php if(!$imperial) echo round($weather['vis_km']); else  echo $this->weather_unit_convert($weather['vis_km'], 'KM_TO_M');?><var><?php if(!$imperial) _e(' KM','mec'); else _e(' Miles','mec'); ?></var></div>
+                    <div class="mec-weather-visibility" data-kph="<?php _e(' KM', 'modern-events-calendar-lite'); ?>" data-mph="<?php _e(' Miles', 'modern-events-calendar-lite'); ?>"><span><?php _e('Visibility', 'modern-events-calendar-lite'); ?>: </span><?php if(!$imperial) echo round($weather['vis_km']); else  echo $this->weather_unit_convert($weather['vis_km'], 'KM_TO_M');?><var><?php if(!$imperial) _e(' KM','modern-events-calendar-lite'); else _e(' Miles','modern-events-calendar-lite'); ?></var></div>
                 <?php endif; ?>
         
             </div>

--- a/app/modules/weather/details.php
+++ b/app/modules/weather/details.php
@@ -30,6 +30,8 @@ $date = (trim($occurrence) ? $occurrence : $event->date['start']['date']).' '.sp
 $weather = $this->get_weather($lat, $lng, $date);
 $imperial = (isset($settings['weather_module_imperial_units']) and $settings['weather_module_imperial_units']) ? true : false;
 
+// Weather not found!
+if(!is_array($weather) or (is_array($weather) and !count($weather))) return;
 ?>
 <div class="mec-weather-details mec-frontbox" id="mec_weather_details">
     <h3 class="mec-weather mec-frontbox-title"><?php _e('Weather', 'modern-events-calendar-lite'); ?></h3>


### PR DESCRIPTION
Since the DarkSky API no longer accepts signups, the module wasn't working. I've changed the source API to weatherAPI.com because it matched darksky very closely.  
The resulting JSON structure has slight name differences, so those have been changed to reference the right parts.

The only real impact on users will be a difference in the icons used by WeatherAPI. These are referencing the WeatherAPI CDN directly. 