### PR TITLE
Modify WhatsApp URL to be compatible with WhatsApp Web

### DIFF
--- a/app/libraries/main.php
+++ b/app/libraries/main.php
@@ -2127,7 +2127,7 @@ class MEC_main extends MEC_base
         $occurrence = (isset($_GET['occurrence']) ? sanitize_text_field($_GET['occurrence']) : '');
         if(trim($occurrence) != '') $url = $this->add_qs_var('occurrence', $occurrence, $url);
 
-        return '<li class="mec-event-social-icon"><a class="whatsapp" href="whatsapp://send/?text='.rawurlencode($url).'" title="'.__('Share on WhatsApp', 'modern-events-calendar-lite').'"><i class="mec-fa-whatsapp"></i></a></li>';
+        return '<li class="mec-event-social-icon"><a class="whatsapp" href="https://wa.me/?text='.rawurlencode($url).'" title="'.__('Share on WhatsApp', 'modern-events-calendar-lite').'"><i class="mec-fa-whatsapp"></i></a></li>';
 
     }
 


### PR DESCRIPTION
The current link to share events via WhatsApp only works when the WhatsApp application is installed. 

After this change in the `href`, it will work on all platforms, including WhatsApp web. 

<br>

> More info: [https://faq.whatsapp.com/general/chats/how-to-use-click-to-chat](https://faq.whatsapp.com/general/chats/how-to-use-click-to-chat)